### PR TITLE
Branch switching redux

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,11 +3,13 @@ PATH
   specs:
     giternal (0.2.0)
       git (~> 1.2)
+      log4r (~> 1.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
     builder (3.0.0)
+    coderay (1.0.7)
     cucumber (1.2.1)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -17,21 +19,28 @@ GEM
     gherkin (2.11.1)
       json (>= 1.4.6)
     git (1.2.5)
-    json (1.7.3)
+    json (1.7.4)
+    log4r (1.1.10)
+    method_source (0.8)
     multi_json (1.3.6)
+    pry (0.9.10)
+      coderay (~> 1.0.5)
+      method_source (~> 0.8)
+      slop (~> 3.3.1)
     rake (0.9.2.2)
     rspec (2.11.0)
       rspec-core (~> 2.11.0)
       rspec-expectations (~> 2.11.0)
       rspec-mocks (~> 2.11.0)
-    rspec-core (2.11.0)
-    rspec-expectations (2.11.1)
+    rspec-core (2.11.1)
+    rspec-expectations (2.11.2)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.1)
     simplecov (0.6.4)
       multi_json (~> 1.0)
       simplecov-html (~> 0.5.3)
     simplecov-html (0.5.3)
+    slop (3.3.2)
 
 PLATFORMS
   ruby
@@ -39,6 +48,7 @@ PLATFORMS
 DEPENDENCIES
   cucumber (~> 1)
   giternal!
+  pry
   rake (~> 0.9)
   rspec (~> 2)
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     giternal (0.2.0)
-      ruby-git (~> 0.2)
+      git (~> 1.2)
 
 GEM
   remote: http://rubygems.org/
@@ -16,6 +16,7 @@ GEM
     diff-lcs (1.1.3)
     gherkin (2.11.1)
       json (>= 1.4.6)
+    git (1.2.5)
     json (1.7.3)
     multi_json (1.3.6)
     rake (0.9.2.2)
@@ -27,7 +28,6 @@ GEM
     rspec-expectations (2.11.1)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.1)
-    ruby-git (0.2.2)
     simplecov (0.6.4)
       multi_json (~> 1.0)
       simplecov-html (~> 0.5.3)

--- a/bin/giternal
+++ b/bin/giternal
@@ -2,17 +2,15 @@
 require 'giternal'
 
 action = ARGV[0]
-actions = Giternal::App.action_names
 
 Giternal::Repository.verbose = true
 begin
   app = Giternal::App.new(FileUtils.pwd)
   app.run(*ARGV)
-rescue Giternal::Error::UnknownCommand => e
-  puts "Unknown command: '#{e.message}'\n"
-  puts "Usage: giternal (#{actions.join(':')})"
+rescue Giternal::Error::UsageError => e
+  puts "#{e.format}\n\n#{Giternal::App.usage}"
+  exit 1
 rescue Giternal::Error::ReportableError => e
-  puts "Usage: giternal (#{actions.join(':')})\n"
-  $stderr.puts e.message
+  puts e.format
   exit 1
 end

--- a/giternal.gemspec
+++ b/giternal.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.post_install_message = "** IMPORTANT - Please see UPGRADING.rdoc for important changes **"
   s.require_paths = ["lib"]
 
-  s.add_dependency("ruby-git", ["~> 0.2"])
+  s.add_dependency("git", ["~> 1.2"])
   s.add_development_dependency("rake", ["~> 0.9"])
   s.add_development_dependency("rspec", ["~> 2"])
   s.add_development_dependency("cucumber", ["~> 1"])

--- a/giternal.gemspec
+++ b/giternal.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("git", ["~> 1.2"])
+  s.add_dependency("log4r", ["~> 1.1"])
+  s.add_development_dependency("pry")
   s.add_development_dependency("rake", ["~> 0.9"])
   s.add_development_dependency("rspec", ["~> 2"])
   s.add_development_dependency("cucumber", ["~> 1"])

--- a/lib/giternal.rb
+++ b/lib/giternal.rb
@@ -2,6 +2,7 @@ module Giternal
 end
 
 require 'giternal/error'
+require 'giternal/logger'
 require 'giternal/repository'
 require 'giternal/yaml_config'
 require 'giternal/app'

--- a/lib/giternal/app.rb
+++ b/lib/giternal/app.rb
@@ -2,6 +2,10 @@ require 'giternal'
 
 module Giternal
   class App
+
+    def self.usage
+      "Usage: giternal <command>\n"
+    end
     
     def self.actions
       App::Actions.instance_methods(false)

--- a/lib/giternal/error.rb
+++ b/lib/giternal/error.rb
@@ -4,8 +4,37 @@ module Giternal
   module Error
     # Exceptions that should be captured and produce user-visible messaging
     # should inherit from ReportableError
-    class ReportableError < StandardError; end
+    class ReportableError < StandardError
+      def format
+        message
+      end
+    end
 
-    class UnknownCommand < ReportableError; end
+    # ReportableErrors that should also show command usage
+    class UsageError < ReportableError; end
+
+    # Reportable and Usage Errors
+    #
+    class NotGitRepo < ReportableError
+      def format
+        "Directory '#{message}' exists but is not a git repository"
+      end
+    end
+
+    class UnknownCommand < UsageError
+      def format
+        "Unknown command: '#{message}'"
+      end
+    end
+
+    # Non-reportable errors
+    #
+    # These must be caught or else they're real and pertinent problems
+    #
+    class NotCheckedOut < StandardError
+      def format
+        "Repository '#{message}' is not checked out"
+      end
+    end
   end
 end

--- a/lib/giternal/logger.rb
+++ b/lib/giternal/logger.rb
@@ -7,6 +7,7 @@ module Giternal
     return @logger if @logger
 
     @logger = (Log4r::Logger['giternal'] || Log4r::Logger.new('giternal'))
+    @logger.level = Log4r::WARN
     @logger.outputters = Log4r::Outputter.stdout
     @logger
   end

--- a/lib/giternal/logger.rb
+++ b/lib/giternal/logger.rb
@@ -1,0 +1,18 @@
+require 'giternal'
+
+require 'log4r'
+
+module Giternal
+  def self.logger
+    return @logger if @logger
+
+    @logger = (Log4r::Logger['giternal'] || Log4r::Logger.new('giternal'))
+    @logger.outputters = Log4r::Outputter.stdout
+    @logger
+  end
+
+  def self.silence_logging
+    # Log4r Null logger idiom from http://log4r.rubyforge.org/manual.html#nullobj
+    @logger = Log4r::Logger.root
+  end
+end

--- a/lib/giternal/repository.rb
+++ b/lib/giternal/repository.rb
@@ -52,7 +52,7 @@ module Giternal
         update_output do
           git.remote.fetch
           if git.branch.name != @branch
-            git.branch(@branch).checkout
+            git.checkout(@branch)
           end
           git.remote.merge(@branch)
         end

--- a/lib/giternal/repository.rb
+++ b/lib/giternal/repository.rb
@@ -25,7 +25,6 @@ module Giternal
     def update
       git_ignore_self
 
-      return true if frozen?
       FileUtils.mkdir_p checkout_path unless File.exist?(checkout_path)
       if checked_out?
         if !File.exist?(repo_path + '/.git')

--- a/lib/giternal/repository.rb
+++ b/lib/giternal/repository.rb
@@ -1,6 +1,8 @@
 require 'giternal'
-
 require 'fileutils'
+require 'pathname'
+
+require 'git'
 
 module Giternal
   class Repository
@@ -9,55 +11,65 @@ module Giternal
     end
     attr_accessor :verbose
 
+    attr_reader :checkout_path
+
     def initialize(base_dir, name, repo_url, rel_path, branch=nil)
-      @base_dir = base_dir
+      @base_dir = Pathname.new(base_dir).expand_path
       @name = name
       @repo_url = repo_url
-      @rel_path = rel_path
+      @rel_path = rel_path || ''
+
       if branch != nil
         @branch = branch
       else
         @branch = "master"
       end
+
+      @checkout_path = (@base_dir + @rel_path).expand_path
+      @repo_path = @checkout_path + @name
       @verbose = self.class.verbose
+    end
+
+    def git
+      begin
+        @git ||= Git.open(@repo_path, :log => Giternal.logger)
+      rescue ArgumentError => e
+        dir = e.backtrace.first
+        if dir =~ /\.git$/
+          raise Giternal::Error::NotGitRepo, dir
+        else
+          raise Giternal::Error::NotCheckedOut, dir
+        end
+      end
     end
 
     def update
       git_ignore_self
 
-      FileUtils.mkdir_p checkout_path unless File.exist?(checkout_path)
+      @checkout_path.mkpath unless @checkout_path.directory?
+
       if checked_out?
-        if !File.exist?(repo_path + '/.git')
-          raise "Directory '#{@name}' exists but is not a git repository"
-        else
-          current_branch = (`cd #{repo_path} && git branch`).split[1]
-          if current_branch != @branch
-            `cd #{repo_path} && git checkout #{@branch}`
+        update_output do
+          git.remote.fetch
+          if git.branch.name != @branch
+            git.branch(@branch).checkout
           end
-          update_output { `cd #{repo_path} && git pull 2>&1` }
+          git.remote.merge(@branch)
         end
       else
-        update_output { `cd #{checkout_path} && git clone #{@repo_url} #{@name} -b #{@branch}` }
+        update_output do
+          @git = Git.clone(@repo_url, @name, :path => @checkout_path.to_s)
+          @git.branch(@branch).checkout
+        end
       end
       true
     end
 
     def checked_out?
-      File.exist?(repo_path)
+      !!(@repo_path.directory? && git)
     end
 
     private
-    def checkout_path
-      File.expand_path(File.join(@base_dir, @rel_path))
-    end
-
-    def repo_path
-      File.expand_path(checkout_path + '/' + @name)
-    end
-
-    def rel_repo_path
-      @rel_path + '/' + @name
-    end
 
     def update_output(&block)
       puts "Updating #{@name}" if verbose
@@ -66,16 +78,22 @@ module Giternal
     end
 
     def git_ignore_self
+      if @rel_path.empty?
+        ignore_path = "/#{@name}"
+      else
+        ignore_path = "/#{@rel_path}/#{@name}"
+      end
+
       Dir.chdir(@base_dir) do
         contents = File.read('.gitignore') if File.exist?('.gitignore')
 
-        unless contents.to_s.include?(rel_repo_path)
+        unless contents.to_s.include?(ignore_path)
           File.open('.gitignore', 'w') do |file|
             if contents
               file << contents
-              file << "\n" unless contents[-1] == 10 # ascii code for \n
+              file << "\n" unless contents[-1] == "\n"
             end
-            file << rel_repo_path << "\n"
+            file << ignore_path << "\n"
           end
         end
       end

--- a/spec/giternal/repository_spec.rb
+++ b/spec/giternal/repository_spec.rb
@@ -92,6 +92,13 @@ module Giternal
           should == 'newfile'
       end
 
+      it "should raise an error if the directory does not exist" do
+        FileUtils.mkdir_p(GiternalHelper.checked_out_path(''))
+        lambda {
+          @repository.git
+        }.should raise_error(Giternal::Error::NotCheckedOut)
+      end
+
       it "should raise an error if the directory exists but there's no .git dir" do
         FileUtils.mkdir_p(GiternalHelper.checked_out_path('foo'))
         lambda {

--- a/spec/giternal_helper.rb
+++ b/spec/giternal_helper.rb
@@ -53,9 +53,12 @@ class GiternalHelper
   end
 
   def self.add_content(repo_name, content=repo_name)
-    Dir.chdir(tmp_path + "/externals/#{repo_name}") do
-      `echo #{content} >> #{content} && git add #{content}`
-      `git commit #{content} -m "added content to #{content}"`
+    without_git_env do
+      Dir.chdir(tmp_path + "/externals/#{repo_name}") do
+        `echo #{content} >> #{content}`
+        `git add #{content}`
+        `git commit #{content} -m "added content to #{content}"`
+      end
     end
   end
 
@@ -76,6 +79,19 @@ class GiternalHelper
   def self.clean!
     FileUtils.rm_rf tmp_path
     %w(GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE).each {|var| ENV[var] = nil }
+  end
+
+  def self.without_git_env
+    gitenv = {}
+    %w(GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE).each do |var|
+      gitenv[var] = ENV[var]
+      ENV[var] = nil
+    end
+    begin
+      yield
+    ensure
+      gitenv.keys.each { |var| ENV[var] = gitenv[var] }
+    end
   end
 
   def self.update_externals(*args)

--- a/spec/giternal_helper.rb
+++ b/spec/giternal_helper.rb
@@ -53,8 +53,8 @@ class GiternalHelper
   end
 
   def self.add_content(repo_name, content=repo_name)
-    without_git_env do
-      Dir.chdir(tmp_path + "/externals/#{repo_name}") do
+    Dir.chdir(tmp_path + "/externals/#{repo_name}") do
+      without_git_env do
         `echo #{content} >> #{content}`
         `git add #{content}`
         `git commit #{content} -m "added content to #{content}"`
@@ -64,7 +64,9 @@ class GiternalHelper
 
   def self.create_branch(repo_name, new_branch)
     Dir.chdir(tmp_path + "/externals/#{repo_name}") do
-      `git checkout -q master -b #{new_branch}`
+      without_git_env do
+        `git checkout -q master -b #{new_branch}`
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,8 @@ end
 require 'giternal'
 require 'giternal_helper'
 
+Giternal.silence_logging
+
 RSpec.configure do |config|
   config.before { GiternalHelper.clean! }
   config.after { GiternalHelper.clean! }


### PR DESCRIPTION
This change is primarily to improve branch switching behavior when the main repo's `.giternal.yml` configuration specifies new branches in the child repositories.  Various test enhancements and refactorings included in passing.
