### PR TITLE
Use the actual current branch in update

### DIFF
--- a/lib/giternal/repository.rb
+++ b/lib/giternal/repository.rb
@@ -51,7 +51,7 @@ module Giternal
       if checked_out?
         update_output do
           git.remote.fetch
-          if git.branch.name != @branch
+          if git.current_branch != @branch
             git.lib.checkout(@branch)
           end
           git.remote.merge(@branch)

--- a/spec/giternal/repository_spec.rb
+++ b/spec/giternal/repository_spec.rb
@@ -174,6 +174,18 @@ module Giternal
         File.read(GiternalHelper.checked_out_path('foo/test_branch_file')).strip.should == 'test_branch_file'
       end
 
+      it "should check out the master branch" do
+        # An empty branch in the config will produce 'nil' to the branch
+        # parameter
+        @repository.update
+        @repository = Repository.new(GiternalHelper.base_project_dir, "foo",
+                                     GiternalHelper.external_url('foo'),
+                                     'dependencies', nil)
+        @repository.update
+        Dir.chdir(GiternalHelper.checked_out_path('foo')) do
+          `git symbolic-ref -q HEAD | sed -e 's|^refs/heads/||'`.strip.should == 'master'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Giternal::Repository.update was not using the correct current branch. It 
seems that the git gem defaults to master when retrieving `git.branch` 
instead of defaulting to the current branch state of the repo.
